### PR TITLE
Manipulate checks via stalker-client

### DIFF
--- a/bin/stalker-client
+++ b/bin/stalker-client
@@ -6,6 +6,65 @@ import sys
 import optparse
 
 
+def _requeue(config, cid):
+    target = config['url'] + '/checks/id/' + cid + '/next'
+    headers = {'X-API-KEY': config['key'], 'Content-Type': 'application/json'}
+    data = {'next': 'now'}
+    try:
+        req = urllib2.Request(target, json.dumps(data), headers=headers)
+        res = urllib2.urlopen(req)
+        content = res.read()
+        print "%s set for recheck." % cid
+    except urllib2.HTTPError as err:
+        if err.code == 404:
+            print "Error. No check with id %s" % cid
+        else:
+            print "Failed. Status: %s Msg: %s" % (err.code, err.reason)
+
+
+def _remove_check(config, cid, name=None):
+    target = config['url'] + '/checks/id/' + cid
+    headers = {'X-API-KEY': config['key'], 'Content-Type': 'application/json'}
+    try:
+        req = urllib2.Request(target, headers=headers)
+        req.get_method = lambda: 'DELETE'
+        res = urllib2.urlopen(req)
+        content = res.read()
+        print "%s deleted." % (name or cid)
+    except urllib2.HTTPError as err:
+        if err.code == 404:
+            print "Error. No check with id %s" % cid
+        else:
+            print "Failed. Status: %s Msg: %s" % (err.code, err.reason)
+
+
+def _remove_host(config, pattern):
+    print "Looking up checks for %s..." % pattern
+    host = _get_checks_by_host(config, pattern)
+    print [i['check'] for i in host['checks']]
+    _ok = raw_input('Ok to remove all these checks? [y/n] ').strip().lower()
+    if _ok != 'y':
+        print "Aborting."
+        return
+    else:
+        for check in host['checks']:
+            _remove_check(config, check['_id'], check['check'])
+
+
+def _get_checks_by_host(config, pattern):
+    target = config['url'] + '/checks/host/' + pattern
+    headers = {'X-API-KEY': config['key'], 'Content-Type': 'application/json'}
+    try:
+        req = urllib2.Request(target, headers=headers)
+        res = urllib2.urlopen(req)
+        return json.loads(res.read())
+    except urllib2.HTTPError as err:
+        if err.code == 404:
+            print "Error. No checks for %s" % pattern
+        else:
+            print "Failed. Status: %s Msg: %s" % (err.code, err.reason)
+
+
 def _pjson(content):
     try:
         import pygments.lexers
@@ -45,6 +104,12 @@ def main():
                     help="Get suspended")
     args.add_option('--verbose', '-v', action="store_true",
                     help="Print out json (fancy if pygments is present")
+    args.add_option('--recheck', dest='recheck_id',
+                    help="Recheck check with given id")
+    args.add_option('--remove', dest='remove_host',
+                    help="Remove all checks for given host or ip")
+    args.add_option('--list', '-l', dest='list_host',
+                    help="List all checks for given host or ip")
     options, arguments = args.parse_args()
 
     conf_file = os.environ.get('stalker-client-conf',
@@ -75,7 +140,14 @@ def main():
 
     if len(sys.argv) == 1:
         options.alerting = True
-
+    if options.recheck_id:
+        _requeue(config, options.recheck_id)
+    if options.remove_host:
+        _remove_host(config, options.remove_host)
+    if options.list_host:
+        host = _get_checks_by_host(config, options.list_host)
+        if host:
+            print json.dumps(host, sort_keys=False, indent=4)
     if options.alerting:
         failed_hosts = set()
         content, parsed = _request(config, 'alerting')
@@ -93,12 +165,12 @@ def main():
             for host in sorted_alerts:
                 for i in sorted_alerts[host]:
                     clean_out = " ".join([x for x in i['out'].split('\n')])
-                    if clean_out.startswith('<urlopen error [Errno'): 
+                    if clean_out.startswith('<urlopen error [Errno'):
                         failed_hosts.add(i['hostname'])
                     else:
-                        print '%s on %s is alerting because "%s"' % (i['check'],
-                                                                     i['hostname'],
-                                                                     clean_out)
+                        print '(%s) %s on %s is alerting because "%s"' % (i['_id'], i['check'],
+                                                                          i['hostname'],
+                                                                          clean_out)
             print "=== Alerting - unreachable ==="
             print " ".join([x for x in failed_hosts])
     if options.pending:

--- a/stalker/stalker_agent.py
+++ b/stalker/stalker_agent.py
@@ -78,7 +78,7 @@ class StalkerAgent(object):
             elif not os.path.isfile(cmd) or not os.access(cmd, os.X_OK):
                 self.logger.warning('%s cmd not executable or not file' % cmd)
             else:
-                self.logger.info('found % check') % cmd
+                self.logger.info('found %s check' % cmd)
                 self.scripts[check] = {'cmd': cmd, 'args': args,
                                        'interval': interval}
 

--- a/stalkerweb/stutils.py
+++ b/stalkerweb/stutils.py
@@ -1,0 +1,28 @@
+from flask import Response
+
+import datetime
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+try:
+    from bson.objectid import ObjectId
+except:
+    pass
+
+
+class APIEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.ctime()
+        elif isinstance(obj, datetime.time):
+            return obj.isoformat()
+        elif isinstance(obj, ObjectId):
+            return str(obj)
+        return json.JSONEncoder.default(self, obj)
+
+def jsonify(data):
+    return Response(json.dumps(data, cls=APIEncoder),
+                    mimetype='application/json')

--- a/stalkerweb/views.py
+++ b/stalkerweb/views.py
@@ -2,12 +2,13 @@ import json
 import eventlet
 eventlet.monkey_patch()
 from eventlet.green import urllib2
-from flask import request, abort, jsonify, render_template, session, redirect
+from flask import request, abort, render_template, session, redirect
 import pymongo
 from bson import ObjectId
 from time import time
 from random import choice
 from stalkerweb.auth import is_valid_login, login_required, remove_user
+from stalkerweb.stutils import jsonify
 from stalkerweb import app, mongo, rc
 from flask.ext.wtf import Form, Required, TextField, PasswordField, \
     BooleanField
@@ -16,7 +17,6 @@ from werkzeug.contrib.cache import RedisCache
 VALID_STATES = ['alerting', 'pending', 'in_maintenance', 'suspended']
 
 cache = RedisCache(default_timeout=app.config['CACHE_TTL'])
-
 
 class SignInForm(Form):
     username = TextField(validators=[Required()])
@@ -269,7 +269,8 @@ def check_next(checkid):
                 return jsonify({'success': True})
             else:
                 abort(404)
-        except (KeyError, ValueError, pymongo.errors.InvalidId):
+        except (KeyError, ValueError, pymongo.errors.InvalidId) as err:
+            print err
             abort(400)
 
 
@@ -308,29 +309,25 @@ def check_suspended(checkid):
 @login_required
 def check_state(state):
     if state == 'alerting':
-        q = [x for x in mongo.db.checks.find({'status': False},
-                                             fields={'_id': False})]
+        q = [x for x in mongo.db.checks.find({'status': False})]
         if q:
             return jsonify({'alerting': q})
         else:
             return jsonify({'alerting': []})
     elif state == 'pending':
-        q = [x for x in mongo.db.checks.find({'pending': True},
-                                             fields={'_id': False})]
+        q = [x for x in mongo.db.checks.find({'pending': True})]
         if q:
             return jsonify({'pending': q})
         else:
             return jsonify({'pending': []})
     elif state == 'in_maintenance':
-        q = [x for x in mongo.db.checks.find({'in_maintenance': True},
-                                             fields={'_id': False})]
+        q = [x for x in mongo.db.checks.find({'in_maintenance': True})]
         if q:
             return jsonify({'in_maintenance': q})
         else:
             return jsonify({'in_maintenance': []})
     elif state == 'suspended':
-        q = [x for x in mongo.db.checks.find({'suspended': True},
-                                             fields={'_id': False})]
+        q = [x for x in mongo.db.checks.find({'suspended': True})]
         if q:
             return jsonify({'suspended': q})
         else:


### PR DESCRIPTION
Fixes #19. Lets stalker-client:
- List checks for a given host/ip
- Remove all checks for a given host/ip
- Initiate a recheck for given check id

stalkerweb now returns the checks _id field in all cases.
