### PR TITLE
Configurable follow-on check intervals

### DIFF
--- a/etc/stalker-agent.conf
+++ b/etc/stalker-agent.conf
@@ -38,6 +38,7 @@
 
 #[check_name must start with check_]
 #interval = override the default interval
+#follow_up = how frequently to check once the check has failed (defaults to the same time as 'interval')
 #cmd = the cmd/script/command to invoke
 #args = any args to pass
 #enabled = defaults to true
@@ -48,6 +49,7 @@ args = -w 90 -c 95 -p /
 
 [check_http]
 interval = 300
+follow_up = 60
 cmd = /usr/lib/nagios/plugins/check_http
 args = -H localhost -u /
 

--- a/stalker/stalker_agent.py
+++ b/stalker/stalker_agent.py
@@ -46,7 +46,7 @@ class StalkerAgent(object):
                 self.scripts[i] = self._script_config(i)
 
     def _script_ok(self, script_name):
-
+        """Verify this is a check script and we have exec perms"""
         tgt = os.path.join(self.script_dir, script_name)
         if os.path.splitext(tgt)[1] == '.cfg':
             return False  # this is a config file
@@ -73,6 +73,7 @@ class StalkerAgent(object):
             args = self.fullconf[check].get('args') or ''
             interval = int(self.fullconf[check].get('interval',
                                                     self.default_interval))
+            follow_up = int(self.fullconf[check].get('follow_up', interval))
             if not cmd:
                 self.logger.warning('No cmd specified for %s skipping' % check)
             elif not os.path.isfile(cmd) or not os.access(cmd, os.X_OK):
@@ -80,7 +81,8 @@ class StalkerAgent(object):
             else:
                 self.logger.info('found %s check' % cmd)
                 self.scripts[check] = {'cmd': cmd, 'args': args,
-                                       'interval': interval}
+                                       'interval': interval,
+                                       'follow_up': follow_up}
 
     def _script_config(self, script_name):
         """Check if theres a .cfg for a given script, if so load the config"""
@@ -91,7 +93,10 @@ class StalkerAgent(object):
             sconf = {}
         return {'cmd': os.path.join(self.script_dir, script_name),
                 'args': sconf.get('args', ''),
-                'interval': int(sconf.get('interval', self.default_interval))}
+                'interval': int(sconf.get('interval', self.default_interval)),
+                'follow_up': int(sconf.get('follow_up',
+                                           sconf.get('interval',
+                                                     self.default_interval)))}
 
     def notify_master(self):
         """Send master our config"""

--- a/stalker/stalker_manager.py
+++ b/stalker/stalker_manager.py
@@ -39,7 +39,8 @@ class StalkerManager(object):
         self.metrics['suspended'] = self.checks.find({'suspended':
                                                      True}).count()
         self.metrics['failing'] = self.checks.find({'status': False}).count()
-        self.metrics['flapping'] = self.checks.find({'flapping': False}).count()
+        self.metrics['flapping'] = self.checks.find(
+            {'flapping': False}).count()
         self.metrics['qsize'] = self.queue_len()
         self.logger.info("stats: %s" % self.metrics)
         self.rc.mset(self.metrics)

--- a/stalker/stalker_notifications.py
+++ b/stalker/stalker_notifications.py
@@ -36,7 +36,8 @@ class PagerDuty(object):
                            'incident_key': incident_key,
                            'event_type': 'resolve',
                            'description': '%s on %s is UP' % (check['check'],
-                                                              check['hostname']),
+                                                              check[
+                                                                  'hostname']),
                            'details': check})
         try:
             req = urllib2.Request(self.url, data, headers)
@@ -65,7 +66,8 @@ class PagerDuty(object):
                            'incident_key': incident_key,
                            'event_type': 'trigger',
                            'description': '%s on %s is DOWN' % (check['check'],
-                                                                check['hostname']),
+                                                                check[
+                                                                    'hostname']),
                            'details': check})
         try:
             req = urllib2.Request(self.url, data, headers)

--- a/stalker/stalker_runner.py
+++ b/stalker/stalker_runner.py
@@ -168,7 +168,7 @@ class StalkerRunner(object):
         previous_status = check['status']
         try:
             result = self._exec_check('https://%s:5050/%s' % (check['ip'],
-                                                             check_name))
+                                                              check_name))
         except Exception as err:
             result = {check_name: {'status': 2, 'out': '', 'err': str(err)}}
             self.statsd.counter('checks.error')
@@ -184,13 +184,13 @@ class StalkerRunner(object):
                                result[check_name]['err'],
                                'fail_count': 0}}
             self.statsd.counter('checks.passed')
-        else:
+        else:  # check is failing
             if previous_status is True:
                 self._flap_incr(flapid)
             query = {'_id': ObjectId(check['_id'])}
             update = {"$set": {'pending': False, 'status': False,
                                'flapping': self.flapping(flapid),
-                               'next': time() + check['interval'],
+                               'next': time() + check['follow_up'],
                                'last': time(),
                                'out': result[check_name]['out'] +
                                result[check_name]['err']},

--- a/stalkerweb/views.py
+++ b/stalkerweb/views.py
@@ -95,14 +95,11 @@ def _valid_registration(content):
             return False
         if not isinstance(content['checks'][check]['interval'], int):
             return False
+        if not isinstance(content['checks'][check]['follow_up'], int):
+            return False
         if 'args' not in content['checks'][check]:
             return False
         if not isinstance(content['checks'][check]['args'], basestring):
-            return False
-    # not actually used right now
-    # validate roles shoudl just be a list of strings
-    for role in content['roles']:
-        if not isinstance(role, basestring):
             return False
     # everything checked out
     return True
@@ -134,6 +131,7 @@ def register():
             bulk_load.append({'hostname': hid, 'ip': request.remote_addr,
                               'check': i, 'last': 0, 'next': _rand_start(),
                               'interval': checks[i]['interval'],
+                              'follow_up': checks[i]['follow_up'],
                               'pending': False,
                               'status': True, 'in_maintenance': False,
                               'suspended': False, 'out': ''})


### PR DESCRIPTION
Adds support for letting checks provide an optional check interval to
use once a check has failed. i.e. if the usual check has an interval of
300, check every 30 seconds once its failed. When the check clears
return to checking every 300 seconds.

Closes #18
