### PR TITLE
Added a few more alert operations

### DIFF
--- a/bin/stalkly
+++ b/bin/stalkly
@@ -72,39 +72,120 @@ class Stalkly(object):
                      'id': 'whatevs', 'out': str(e)}]
 
     def alertwindow(self, window, alert):
-        newwin = window.subwin(18, 80, 2, 0)
+        newwin = window.subwin(22, 80, 2, 0)
         newwin.keypad(True)
-        options = ('Do Nothing', 'Claim', 'Remove Claim', 'Suspend')
+        options = (
+                'Do nothing',
+                'Claim',
+                'Claim all alerts for this server',
+                'Remove claim',
+                'Remove claim for all alerts for this server',
+                'Recheck',
+                'Recheck all alerts for this server',
+                'Suspend',
+                'Remove check',
+                'Remove host'
+            )
         selected = 0
         while True:
             newwin.erase()
             newwin.box()
-            newwin.addstr(1, 1, ' Update Alert..')
+            newwin.addstr(1, 1,  "  Alert Operations")
             newwin.chgat(1, 1, 78, curses.A_BOLD | curses.color_pair(2))
-            newwin.addstr(3, 1, " %(cluster)s / %(hostname)s" % alert)
-            newwin.addnstr(4, 1, ' ' + alert['check'], 75)
+            newwin.addstr(3, 1,  "  Cluster:     " + alert['cluster'])
+            newwin.addstr(4, 1,  "  Host:        " + alert['hostname'])
+            newwin.addnstr(5, 1, "  Check:       " + alert['check'], 75)
+            newwin.addstr(6, 1,  "  Last update: " + time.strftime('%c',
+                                                   time.gmtime(alert['last'])))
+            newwin.addstr(7, 1,  "  Next check:  " + time.strftime('%c',
+                                                   time.gmtime(alert['next'])))
             newwin.addnstr(
-                5, 1, ' ' + alert['out'].split(';')[0].replace('\n', ' '), 75)
+                8, 1, '  Error:       ' + \
+                alert['out'].split(';')[0].replace('\n', ' '), 75)
             for y, option in enumerate(options):
-                newwin.addnstr(y + 8, 3, option, 75)
+                newwin.addnstr(y + 10, 3, option, 75)
                 if y == selected:
-                    newwin.chgat(y + 8, 3, 75, curses.A_REVERSE)
+                    newwin.chgat(y + 10, 3, 75, curses.A_REVERSE)
             key = newwin.getch()
             if key in (ord('\n'), curses.KEY_ENTER):
                 if options[selected] == 'Claim':
                     self.json_request(
-                        '/checks/id/' + alert['id'] + '/owner',
-                        'POST', {'owner': self.username}, alert['cluster'])
+                            '/checks/id/' + alert['id'] + '/owner',
+                            'POST', {'owner': self.username}, alert['cluster']
+                        )
                     alert['owner'] = self.username
+
+                elif options[selected] == 'Claim all alerts for this server':
+                    server_alerts = self.json_request(
+                            '/checks/host/'+ alert['hostname'],
+                            'GET', {}, alert['cluster']
+                        )
+                    for server_alert in server_alerts['checks']:
+                        if server_alert.has_key('_id'):
+                            server_alert['id'] = server_alert.pop('_id')
+                        self.json_request(
+                                '/checks/id/' + server_alert['id'] + '/owner',
+                                'POST', {'owner': self.username},
+                                alert['cluster']
+                            )
+
                 elif options[selected] == 'Remove Claim':
                     self.json_request('/checks/id/' + alert['id'] + '/owner',
                                       'DELETE', {}, alert['cluster'])
                     alert['owner'] = ''
+
+                elif options[selected] == 'Remove claim for all alerts for this server':
+                    server_alerts = self.json_request(
+                            '/checks/host/'+ alert['hostname'],
+                            'GET', {}, alert['cluster']
+                        )
+                    for server_alert in server_alerts['checks']:
+                        if server_alert.has_key('_id'):
+                            server_alert['id'] = server_alert.pop('_id')
+                        self.json_request(
+                                '/checks/id/' + server_alert['id'] + '/owner',
+                                'DELETE', {}, alert['cluster']
+                            )
+
+                elif options[selected] == 'Recheck':
+                    self.json_request(
+                            '/checks/id/' + alert['id'] + '/next',
+                            'POST', {"next": "now"}, alert['cluster']
+                        )
+
+                elif options[selected] == 'Recheck all alerts for this server':
+                    server_alerts = self.json_request(
+                            '/checks/host/'+ alert['hostname'],
+                            'GET', {}, alert['cluster']
+                        )
+                    for server_alert in server_alerts['checks']:
+                        if server_alert.has_key('_id'):
+                            server_alert['id'] = server_alert.pop('_id')
+                        self.json_request(
+                                '/checks/id/' + server_alert['id'] + '/next',
+                                'POST', {"next": "now"}, alert['cluster']
+                            )
+
                 elif options[selected] == 'Suspend':
                     self.json_request(
-                        '/checks/id/' + alert['id'] + '/suspended',
-                        'POST', {'suspended': True}, alert['cluster'])
+                            '/checks/id/' + alert['id'] + '/suspended',
+                            'POST', {'suspended': True}, alert['cluster']
+                        )
+
+                elif options[selected] == 'Remove check':
+                    self.json_request(
+                            '/checks/id/' + alert['id'],
+                            'DELETE', {}, alert['cluster']
+                        )
+
+                elif options[selected] == 'Remove host':
+                    self.json_request(
+                            '/hosts/' + alert['hostname'],
+                            'DELETE', {}, alert['cluster']
+                        )
+
                 break
+
             elif key in (ord('k'), curses.KEY_UP):
                 selected = (selected - 1) % len(options)
             elif key in (ord('\t'), ord('j'), curses.KEY_DOWN):
@@ -187,9 +268,9 @@ class Stalkly(object):
                 selected += 1
             elif key in (ord('k'), curses.KEY_UP):
                 selected -= 1
-            elif key in (ord('g'), curses.KEY_HOME):
+            elif key == ord('g'):
                 selected = 0
-            elif key in (ord('G'), curses.KEY_END):
+            elif key == ord('G'):
                 selected = len(alerting) - 1
             elif key in (ord(curses.ascii.ctrl('d')), curses.KEY_NPAGE):
                 selected += height - 2


### PR DESCRIPTION
Now you can claim/unclaim all alerts for a certain host, recheck one or all the alerts for a certain host or completely remove a host.
The only unsolved issue is that you need to manually refresh after issuing the command.