### PR TITLE
Fix env for scripts not in the config file

### DIFF
--- a/stalker/stalker_agent.py
+++ b/stalker/stalker_agent.py
@@ -109,7 +109,7 @@ class StalkerAgent(object):
         else:
             sconf = {}
         return {'cmd': os.path.join(self.script_dir, script_name),
-                'args': sconf.get('args', ''),
+                'args': sconf.get('args', ''), 'env': sconf.get('env', ''),
                 'interval': int(sconf.get('interval', self.default_interval)),
                 'priority': int(sconf.get('priority', self.default_priority)),
                 'follow_up': int(sconf.get('follow_up',


### PR DESCRIPTION
Without this `environ.update(self.scripts[script]['env'])` at line 147 will assume env is there and explode causing a fake 500 error on the agent.